### PR TITLE
Add Incomplete, Committed, and Point Change metrics to the Sprint Report

### DIFF
--- a/src/main/java/com/ashkan/jira/service/SprintReport.java
+++ b/src/main/java/com/ashkan/jira/service/SprintReport.java
@@ -26,6 +26,7 @@ public class SprintReport {
 	private int injected = 0;
 	private int injectedStoryPoints = 0;
 	private int committed = 0;
+	private int committedStoryPoints = 0;
 	private int inflated = 0;
 	private int inflatedStoryPoints = 0;
 	private int deflated = 0;
@@ -63,6 +64,11 @@ public class SprintReport {
 				injected++;
 				injectedStoryPoints += getStoryPoints(jsonIssue);
 				System.out.println("Injected Ticket No:");
+				System.out.println(jsonIssue.getString("key"));
+			} else {
+				committed++;
+				committedStoryPoints += getStoryPoints(jsonIssue);
+				System.out.println("Committed Ticket No:");
 				System.out.println(jsonIssue.getString("key"));
 			}
 
@@ -236,6 +242,8 @@ public class SprintReport {
 		System.out.println("Incomplete story points: " + incompleteStoryPoints);
 		System.out.println("Injected stories: " + injected);
 		System.out.println("Injected story points: " + injectedStoryPoints);
+		System.out.println("Committed stories: " + committed);
+		System.out.println("Committed story points: " + committedStoryPoints);
 		System.out.println("Inflated stories: " + inflated);
 		System.out.println("Inflated story points: " + inflatedStoryPoints);
 		System.out.println("Deflated stories: " + deflated);

--- a/src/main/java/com/ashkan/jira/service/SprintReport.java
+++ b/src/main/java/com/ashkan/jira/service/SprintReport.java
@@ -23,6 +23,7 @@ public class SprintReport {
 	private int inflated = 0;
 	private int removed = 0;
 	private int incomplete = 0;
+	private int incompleteStoryPoints = 0;
 
 	private final JiraService jiraService;
 
@@ -42,7 +43,13 @@ public class SprintReport {
 				completedStoryPoints += getStoryPoints(jsonIssue);
 				System.out.println("Completed Ticket No:");
 				System.out.println(jsonIssue.getString("key"));
+			} else {
+				incomplete++;
+				incompleteStoryPoints += getStoryPoints(jsonIssue);
+				System.out.println("Incomplete Ticket No:");
+				System.out.println(jsonIssue.getString("key"));
 			}
+
 			if (isIssueInjected(jsonIssue, currentSprint)) {
 				injected++;
 				injectedStoryPoints += getStoryPoints(jsonIssue);
@@ -152,6 +159,8 @@ public class SprintReport {
 	private void printSprintReport() {
 		System.out.println("Completed issues: " + completed);
 		System.out.println("Completed story points: " + completedStoryPoints);
+		System.out.println("Incomplete issues: " + incomplete);
+		System.out.println("Incomplete story points: " + incompleteStoryPoints);
 		System.out.println("Injected stories: " + injected);
 		System.out.println("Injected story points: " + injectedStoryPoints);
 	}

--- a/src/main/java/com/ashkan/jira/service/SprintReport.java
+++ b/src/main/java/com/ashkan/jira/service/SprintReport.java
@@ -1,5 +1,7 @@
 package com.ashkan.jira.service;
 
+import lombok.RequiredArgsConstructor;
+
 import com.ashkan.jira.model.Sprint;
 import com.ashkan.jira.util.JiraTime;
 import org.json.JSONArray;
@@ -12,15 +14,22 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Comparator;
+import java.util.SortedSet;
+import java.util.TreeSet;
 
 @Component
 public class SprintReport {
+	private static final String STORY_POINTS_FIELD_ID = "customfield_10200";
 	private int completed = 0;
 	private int completedStoryPoints = 0;
 	private int injected = 0;
 	private int injectedStoryPoints = 0;
 	private int committed = 0;
 	private int inflated = 0;
+	private int inflatedStoryPoints = 0;
+	private int deflated = 0;
+	private int deflatedStoryPoints = 0;
 	private int removed = 0;
 	private int incomplete = 0;
 	private int incompleteStoryPoints = 0;
@@ -54,6 +63,19 @@ public class SprintReport {
 				injected++;
 				injectedStoryPoints += getStoryPoints(jsonIssue);
 				System.out.println("Injected Ticket No:");
+				System.out.println(jsonIssue.getString("key"));
+			}
+
+			int pointChange = getIssuePointChange(jsonIssue, currentSprint);
+			if (pointChange > 0) {
+				inflated++;
+				inflatedStoryPoints += pointChange;
+				System.out.println("Inflated Ticket No:");
+				System.out.println(jsonIssue.getString("key"));
+			} else if (pointChange < 0) {
+				deflated++;
+				deflatedStoryPoints += pointChange;
+				System.out.println("Deflated Ticket No:");
 				System.out.println(jsonIssue.getString("key"));
 			}
 		}
@@ -96,7 +118,7 @@ public class SprintReport {
 	private int getStoryPoints(JSONObject issue) {
 		int storyPoints = 0;
 		try {
-			storyPoints = issue.getJSONObject("fields").getInt("customfield_10200");
+			storyPoints = issue.getJSONObject("fields").getInt(STORY_POINTS_FIELD_ID);
 		} catch (JSONException e) {
 			// Ticket has no story points (field value is null)
 			StringWriter sw = new StringWriter();
@@ -156,6 +178,57 @@ public class SprintReport {
 		return false;
 	}
 
+	@RequiredArgsConstructor
+	private static class StoryPointChanges {
+		private final int points;
+		private final Instant timeAdded;
+	}
+
+	public int getIssuePointChange(JSONObject jsonIssue, Sprint currentSprint) {
+		JSONArray changelog = jsonIssue.getJSONObject("changelog").getJSONArray("histories");
+		int endPoints = getStoryPoints(jsonIssue);
+
+		SortedSet<StoryPointChanges> pointsLog = new TreeSet<>(Comparator.comparing(change -> change.timeAdded));
+
+		for (Object log : changelog) {
+			JSONObject jsonLog = (JSONObject) log;
+			JSONArray items = jsonLog.getJSONArray("items");
+			Instant changeTime = JiraTime.getInstant(jsonLog.getString("created"));
+			for (Object item : items) {
+				JSONObject jsonItem = (JSONObject) item;
+				try {
+					if (jsonItem.has("fieldId") && jsonItem.get("fieldId").equals(STORY_POINTS_FIELD_ID)) {
+						// there was a change in story points!
+						int points;
+						if (jsonItem.get("toString").equals("")) {
+							points = 0;
+						} else {
+							points = jsonItem.getInt("toString");
+						}
+						pointsLog.add(new StoryPointChanges(points, changeTime));
+					}
+				} catch (JSONException e) {
+					System.out.println("NO:");
+					System.out.println(jsonItem.toString());
+				}
+			}
+		}
+
+		Instant sprintStart = currentSprint.getStart();
+
+		// all changes that happened before the sprint started
+		SortedSet<StoryPointChanges> changesAfterStart = pointsLog.headSet(new StoryPointChanges(0, sprintStart));
+		if (changesAfterStart.isEmpty()) {
+			return 0;
+		}
+
+		// points on the latest change
+		// this tells us how many points the ticket had at the start of the sprint
+		int startPoints = changesAfterStart.last().points;
+
+		return endPoints - startPoints;
+	}
+
 	private void printSprintReport() {
 		System.out.println("Completed issues: " + completed);
 		System.out.println("Completed story points: " + completedStoryPoints);
@@ -163,5 +236,9 @@ public class SprintReport {
 		System.out.println("Incomplete story points: " + incompleteStoryPoints);
 		System.out.println("Injected stories: " + injected);
 		System.out.println("Injected story points: " + injectedStoryPoints);
+		System.out.println("Inflated stories: " + inflated);
+		System.out.println("Inflated story points: " + inflatedStoryPoints);
+		System.out.println("Deflated stories: " + deflated);
+		System.out.println("Deflated story points: " + deflatedStoryPoints);
 	}
 }


### PR DESCRIPTION
1. Incomplete issues are easy: they're just any issues that are not complete! 
2. Committed issues are also easy: they're any issues that weren't injected!
3. Issues where the points changed (either "inflated" or "deflated") are a little more complicated. We go through the history on the item and look for all of the changes to the "Story Points" field. Then, we stick those in a `SortedSet`, which sorts by time for us. 

See we'll end up with a set of things like this:
```
Jan 10 2020 10:12 AM: 8 points
Jan 20 2020 12:45 PM: 13 points
Jan 25 2020 5:02 PM: 20 points
```

Then we call `headSet(sprintStart)`, which gives us all of the entries in the set that sort lower than `sprintStart`; ie. they happened _before_ the sprint started. 

Then we call `last()` on the result to get the _latest_ point value before the sprint started. 

In the example above, if our sprint started on Jan 22 2020, then `headSet()` would give us

```
Jan 10 2020 10:12 AM: 8 points
Jan 20 2020 12:45 PM: 13 points
```

and `.last()` would give us the entry `Jan 20 2020 12:45 PM: 13 points`. 

Then we pull the points out of that object and compare it to the current value of points on the ticket. This tells us if the point value went up during the sprint (inflated) or went down during the sprint (deflated) or stayed the same, and we stick it in the report accordingly. 
